### PR TITLE
fix: update sql server odbc18 & new path

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -83,7 +83,7 @@ jobs:
         options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
       mssql:
-        image: mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+        image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
         env:
           SA_PASSWORD: 1Secure*Password1
           ACCEPT_EULA: Y

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -88,9 +88,10 @@ jobs:
           SA_PASSWORD: 1Secure*Password1
           ACCEPT_EULA: Y
           MSSQL_PID: Developer
+          MSSQL_ENCRYPT: optional
         ports:
           - 1433:1433
-        options: --health-cmd="/opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION' -N -C" --health-interval=10s --health-timeout=5s --health-retries=3
 
       oracle:
         image: gvenzl/oracle-xe:18


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
I've done some research and concluded that we can resolve the PHPUnit test failures with the following changes:
```console
This program has encountered a fatal error and cannot continue running at Fri Oct  4 03:45:30 2024
   The following diagnostic information is available:
   SQL Server 2019 will run as non-root by default.
   This container is running as user mssql.
   To learn more visit https://go.microsoft.com/fwlink/?linkid=2099216.
```
ODBC Driver 18.0 Settings: Set the Encrypt option to optional and ensure that we use the new path /opt/mssql-tools18/bin/sqlcmd.

See : 

1. https://github.com/codeigniter4/shield/actions/runs/11173623167/job/31061981817
2. https://techcommunity.microsoft.com/t5/sql-server-blog/odbc-driver-18-0-for-sql-server-released/ba-p/3169228
3. https://sqlserverupdates.com/sql-server-2019-updates/

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
