### PR TITLE
fix: update oracle and sqlsrv images

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -83,18 +83,21 @@ jobs:
         options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
       mssql:
-        image: mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
-          SA_PASSWORD: 1Secure*Password1
+          MSSQL_SA_PASSWORD: 1Secure*Password1
           ACCEPT_EULA: Y
           MSSQL_PID: Developer
-          MSSQL_ENCRYPT: optional
         ports:
           - 1433:1433
-        options: --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION' -N -C" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -C -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
       oracle:
-        image: gvenzl/oracle-xe:18
+        image: gvenzl/oracle-xe:21
         env:
           ORACLE_RANDOM_PASSWORD: true
           APP_USER: ORACLE

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Create database for MSSQL Server
         if: matrix.db-platforms == 'SQLSRV'
-        run: sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q "CREATE DATABASE test"
+        run: /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q "CREATE DATABASE test"
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   main:
     name: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:


### PR DESCRIPTION
**Description**
This PR updates the images for Oracle and SQLSRV databases.

The current image for SQLSRV does not work anymore, see: https://github.com/codeigniter4/tasks/actions/runs/12851880571/job/35833377897

I have aligned versions to the one used in the main repository: https://github.com/codeigniter4/CodeIgniter4/blob/develop/.github/workflows/reusable-phpunit-test.yml#L95

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
