### PR TITLE
Update service versions

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Dependency Tracing
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
 
     steps:
       - name: Checkout

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           tools: infection, phpunit
           extensions: intl, json, mbstring, gd, xml, sqlite3
           coverage: xdebug

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -22,7 +22,7 @@ jobs:
   main:
     name: Mutation Testing
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpcpd.yml
+++ b/.github/workflows/phpcpd.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     name: Code Copy-Paste Detection
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     name: PHP ${{ matrix.php-versions }} Coding Standards
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: PHP ${{ matrix.php-versions }} Static Analysis
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/phpunit-lowest.yml
+++ b/.github/workflows/phpunit-lowest.yml
@@ -31,7 +31,7 @@ jobs:
   main:
     name: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }} - ${{ matrix.dependencies }}
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:
         php-versions: ['8.1']

--- a/.github/workflows/phpunit-no-db.yml
+++ b/.github/workflows/phpunit-no-db.yml
@@ -31,7 +31,7 @@ jobs:
   main:
     name: PHP ${{ matrix.php-versions }} Unit Tests
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:
         php-versions: ['8.1', '8.2', '8.3']

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -37,7 +37,7 @@ jobs:
   main:
     name: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }}
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:
         php-versions: ['8.1', '8.2', '8.3']

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   main:
     name: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:
@@ -83,17 +83,21 @@ jobs:
         options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
       mssql:
-        image: mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
-          SA_PASSWORD: 1Secure*Password1
+          MSSQL_SA_PASSWORD: 1Secure*Password1
           ACCEPT_EULA: Y
           MSSQL_PID: Developer
         ports:
           - 1433:1433
-        options: --health-cmd="/opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -C -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
       oracle:
-        image: gvenzl/oracle-xe:18
+        image: gvenzl/oracle-xe:21
         env:
           ORACLE_RANDOM_PASSWORD: true
           APP_USER: ORACLE

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Psalm Analysis
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
 
     steps:
       - name: Checkout

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: PHP ${{ matrix.php-versions }} Rector Analysis
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unused.yml
+++ b/.github/workflows/unused.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     name: Unused Package Detection
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: (! contains(github.event.head_commit.message, '[ci skip]'))
 
     steps:
       - name: Checkout


### PR DESCRIPTION
**Description**
This PR updates service versions to those recently added to the main branch.

**CI45** is used by the playground repo: https://github.com/codeigniter4projects/playground/actions/runs/12925261409/job/36045854831?pr=237

I will probably add **CI46** branch here, but for now, we should keep **CI45** branch up and running.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
