### PR TITLE
chore: update infection workflow

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Run Infection for added files only
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --only-covered --logger-github
+          infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --logger-github


### PR DESCRIPTION
**Description**
This PR updates the infection workflow.

The `--only-covered` flag was removed in Infection 0.31.0, see: https://infection.github.io/guide/command-line-options.html#only-covered

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
