### PR TITLE
feat: configurable php versions

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -18,6 +18,11 @@ on:
       - 'deptrac.yaml'
       - '.github/workflows/deptrac.yml'
   workflow_call:
+    inputs:
+      php-version:
+        required: false
+        type: string
+        default: '8.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -39,7 +44,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs['php-version'] }}
           tools: composer
           extensions: intl, json, mbstring, xml
           coverage: none

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -10,6 +10,11 @@ on:
       - 'phpunit*'
       - '.github/workflows/infection.yml'
   workflow_call:
+    inputs:
+      php-version:
+        required: false
+        type: string
+        default: '8.2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -31,7 +36,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs['php-version'] }}
           tools: infection, phpunit
           extensions: intl, json, mbstring, gd, xml, sqlite3
           coverage: xdebug

--- a/.github/workflows/phpcpd.yml
+++ b/.github/workflows/phpcpd.yml
@@ -23,6 +23,10 @@ on:
         description: Options to phpcpd
         required: false
         type: string
+      php-version:
+        required: false
+        type: string
+        default: '8.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -44,7 +48,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs['php-version'] }}
           tools: phpcpd
           extensions: dom, mbstring
           coverage: none

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -14,6 +14,11 @@ on:
       - '**.php'
       - '.github/workflows/phpcsfixer.yml'
   workflow_call:
+    inputs:
+      php-versions:
+        required: false
+        type: string
+        default: '["8.1", "8.4"]'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -30,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.4']
+        php-versions: ${{ fromJson(inputs.php-versions) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,6 +18,11 @@ on:
       - 'phpstan*'
       - '.github/workflows/phpstan.yml'
   workflow_call:
+    inputs:
+      php-versions:
+        required: false
+        type: string
+        default: '["8.1", "8.2", "8.3", "8.4"]'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -34,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ${{ fromJson(inputs.php-versions) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpunit-no-db.yml
+++ b/.github/workflows/phpunit-no-db.yml
@@ -19,6 +19,11 @@ on:
       - 'phpunit*'
       - '.github/workflows/phpunit-no-db.yml'
   workflow_call:
+    inputs:
+      php-versions:
+        required: false
+        type: string
+        default: '["8.1", "8.2", "8.3", "8.4"]'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -34,7 +39,7 @@ jobs:
     if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ${{ fromJson(inputs.php-versions) }}
         dependencies: ['highest', 'lowest']
 
     steps:
@@ -80,7 +85,7 @@ jobs:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled
 
-      - if: matrix.php-versions == '8.1'
+      - if: ${{ matrix.php-versions == fromJson(inputs.php-versions)[0] }}
         name: Run Coveralls
         continue-on-error: true
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,6 +19,11 @@ on:
       - 'phpunit*'
       - '.github/workflows/phpunit.yml'
   workflow_call:
+    inputs:
+      php-versions:
+        required: false
+        type: string
+        default: '["8.1", "8.2", "8.3", "8.4"]'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -40,25 +45,25 @@ jobs:
     if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ${{ fromJson(inputs.php-versions) }}
         db-platforms: ['MySQLi', 'SQLite3']
         mysql-versions: ['8.0']
         dependencies: ['highest']
         include:
           # MySQL 5.7
-          - php-versions: '8.1'
+          - php-versions: ${{ fromJson(inputs.php-versions)[0] }}
             db-platforms: MySQLi
             mysql-versions: '5.7'
           # Postgre
-          - php-versions: '8.1'
+          - php-versions: ${{ fromJson(inputs.php-versions)[0] }}
             db-platforms: Postgre
             mysql-versions: '8.0'
           # SQLSRV
-          - php-versions: '8.1'
+          - php-versions: ${{ fromJson(inputs.php-versions)[0] }}
             db-platforms: SQLSRV
             mysql-versions: '8.0'
           # OCI8
-          - php-versions: '8.1'
+          - php-versions: ${{ fromJson(inputs.php-versions)[0] }}
             db-platforms: OCI8
             mysql-versions: '8.0'
 
@@ -171,7 +176,7 @@ jobs:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled
 
-      - if: matrix.php-versions == '8.1'
+      - if: ${{ matrix.php-versions == fromJson(inputs.php-versions)[0] }}
         name: Run Coveralls
         continue-on-error: true
         run: |

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -18,6 +18,11 @@ on:
       - 'psalm*'
       - '.github/workflows/psalm.yml'
   workflow_call:
+    inputs:
+      php-version:
+        required: false
+        type: string
+        default: '8.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -39,7 +44,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ inputs['php-version'] }}
           tools: phpstan, phpunit
           extensions: intl, json, mbstring, xml
           coverage: none

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -18,6 +18,11 @@ on:
       - 'rector.php'
       - '.github/workflows/rector.yml'
   workflow_call:
+    inputs:
+      php-versions:
+        required: false
+        type: string
+        default: '["8.1", "8.4"]'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -34,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.4']
+        php-versions: ${{ fromJson(inputs.php-versions) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/unused.yml
+++ b/.github/workflows/unused.yml
@@ -16,6 +16,11 @@ on:
       - 'composer.*'
       - '.github/workflows/unused.yml'
   workflow_call:
+    inputs:
+      php-version:
+        required: false
+        type: string
+        default: '8.2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -37,7 +42,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs['php-version'] }}
           tools: composer, composer-unused
           extensions: intl, json, mbstring, xml
           coverage: none


### PR DESCRIPTION
**Description**
This PR introduces the ability to configure PHP versions across multiple reusable workflow templates.

All workflows now accept a `php-versions` or `php-version` input (depending on a workflow template), which allows users to override the default PHP versions used during workflow run. The default values remain unchanged, so existing workflows will continue to work without modification.

To customize the PHP versions in your project, you can now pass the input like this:
```
jobs:
  example:
    uses: codeigniter4/.github/.github/workflows/example.yml
    with:
      php-versions: '["8.2", "8.4"]'  # Use this for workflows that support multiple PHP versions (matrix)
      # php-version: '8.2'            # Use this if the workflow supports only a single PHP version

```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
