### PR TITLE
chore(ga): Update PHP version from 8.1 to 8.2 in Deptrac

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           tools: composer
           extensions: intl, json, mbstring, xml
           coverage: none


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Latest `deptrac/deptrac` version has minimum `PHP 8.2`.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
